### PR TITLE
doc: Add Xxlvw extension intrinsic usage notes for no vd parameter in…

### DIFF
--- a/source/toolchain/gnu/intro.rst
+++ b/source/toolchain/gnu/intro.rst
@@ -84,6 +84,10 @@ Extensions Support
 
     :ref:`xxlvqmacc <toolchain_gnu_nuclei_vpu>`
 
+- Nuclei custom XXLVW Extensions
+
+    :ref:`xxlvvw <toolchain_gnu_nuclei_xxlvw>`
+
 .. note::
 
     Extensions starting with **x** are generally reserved for manufacturers to customize, and should be placed after extensions starting with **z** when used.

--- a/source/toolchain/gnu/nuclei_xxlvw.rst
+++ b/source/toolchain/gnu/nuclei_xxlvw.rst
@@ -204,6 +204,15 @@ Nuclei 自定义的 intrinsic
     vint32m4_t  __riscv_xl_vdsmacini_v_i32m4(vint32m4_t vs2, size_t vl);
     vint32m8_t  __riscv_xl_vdsmacini_v_i32m8(vint32m8_t vs2, size_t vl);
 
+.. note::
+
+    虽然该指令没有 ``vd parametter``，但是该指令的intrinsic使用时是需要一个返回值的，其返回值不为空。
+
+    暂时没有 ``vd parametter`` 的指令intrinsic，都需要一个返回值。
+
+    未来该类型指令的intrinsic的使用方法可能会有变化，目前只是一个workaround版本。
+
+
 * ``vdsmacini.s``  sew = 8/16/32  none_m_preds[none,_m]
 
 .. code-block:: c

--- a/source/toolchain/gnu/nuclei_xxlvw.rst
+++ b/source/toolchain/gnu/nuclei_xxlvw.rst
@@ -206,9 +206,9 @@ Nuclei 自定义的 intrinsic
 
 .. note::
 
-    虽然该指令没有 ``vd parametter``，但是该指令的intrinsic使用时是需要一个返回值的，其返回值不为空。
+    虽然该指令没有 ``vd parameter``，但是该指令的intrinsic使用时是需要一个返回值的，其返回值不为空。
 
-    暂时没有 ``vd parametter`` 的指令intrinsic，都需要一个返回值。
+    暂时没有 ``vd parameter`` 的指令intrinsic，都需要一个返回值。
 
     未来该类型指令的intrinsic的使用方法可能会有变化，目前只是一个workaround版本。
 


### PR DESCRIPTION
1、为xxlvw扩展的没有vd 参数的指令（vdsmacini.v等）其对应的intrinsic的使用，添加一个说明，防止使用的时候产生误解    
从指令的功能描述上，确实更倾向于没有返回值，但目前的实现上，intrinsic 是需要一个返回值才能够正常的使用   

<img width="1322" height="598" alt="image" src="https://github.com/user-attachments/assets/553be671-f0cf-49ba-b8ec-09f6e3bb62e2" />

所以添加一个说明       
2、为开始的Extension Support界面添加一个链接，能跳转到xxlvw扩展


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds documentation for XXLVW extension intrinsics requiring return values and links to the extension in the documentation.
> 
>   - **Documentation**:
>     - Adds a note in `nuclei_xxlvw.rst` explaining that intrinsics for instructions without a `vd` parameter require a return value.
>     - Adds an example in `nuclei_xxlvw.rst` demonstrating the usage of such intrinsics.
>   - **Navigation**:
>     - Adds a link to the XXLVW extension in `intro.rst` under the Extensions Support section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for bc712335f85381e96bc02ea530ca45c8b7003fbb. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->