### PR TITLE
doc: update gnu and  llvm docs for 2025.10 release

### DIFF
--- a/source/toolchain/changelog.rst
+++ b/source/toolchain/changelog.rst
@@ -1,4 +1,4 @@
-.. toolchain_changelog:
+.. _toolchain_changelog:
 
 Changelog
 =========

--- a/source/toolchain/changelog.rst
+++ b/source/toolchain/changelog.rst
@@ -1,0 +1,112 @@
+.. toolchain_changelog:
+
+Changelog
+=========
+
+.. note::
+
+    To check the known issues encountered after the toolchain release, please refer to the content at the following link:
+
+    - `Known Issues <https://github.com/riscv-mcu/riscv-gnu-toolchain/issues/18>`_
+
+.. _toolchain_changelog_202510:
+
+Version 2025.10
+---------------
+
+- Updated toolchain components to their latest upstream versions: GCC 14.2.1, Binutils 2.44, GDB 16.2, Newlib 4.5.0, LLVM 19.1.7, and GLIBC 2.41.
+
+- Feature: Windows newlib GCC now supports Win32_x64 (64-bit), replacing Win32 (32-bit).
+
+- Feature: Added auto-generation support for the ``Zcmt`` extension.
+
+- Feature: Initial support for ``ECLIC v2`` instructions and CSRs added to Binutils and GDB.
+
+- Feature: Added multilib support for ``Zfinx``, ``Zdinx``, and related extensions.
+
+- Feature: Binutils and GDB now add support for ``Virtual Supervisor-level`` CSRs.
+
+- Feature: Add missing ``fcvt.d.h/fcvt.h.d`` instructions for ``Xxlfbf`` extension.
+
+- Feature: Added ``Xxlvw`` extension support.
+
+- Feature: Add a new -maddibne/-mno-addibne option to control whether Xxlcz's addibne instruction is auto-generated.
+
+- Performance optimization: Aligned Newlib memory/string routines (memcpy/memset/setjmp/strcmp/strcpy/strlen) to 4-byte boundaries.
+
+- Fixed: Compilation issues with semihosting functions ``_times`` and ``_gettimeofday`` in Newlib.
+
+- Fixed: Incorrect inline assembly translation for the ``clrov`` instruction in Xxldsp (Binutils).
+
+- Fixed: Conflicts between the ``Xxlvfbf`` extension and ``Zvfbfmin/Zvfbfwma`` extensions.
+
+- Fixed: Fix codegen regression in branch condition optimization by removing redundant AND -1 instruction.
+
+- Fixed: Fix unnecessary ``slli/srai`` instruction generation when using int16 type.
+
+- LLVM: Initial implementation of pipeline support for Nuclei processor ``100/200/300/600/900/1000`` series.
+
+- LLVM: Added scalar BFloat16 support for Nuclei processors.
+
+- LLVM: Implemented Nuclei-specific VPU matrix instructions.
+
+- LLVM: Added missing ``Virtual Supervisor-level`` CSRs (hedelegh/medelegh) support in LLVM
+
+.. _toolchain_changelog_202502:
+
+Version 2025.02
+---------------
+
+- Updated toolchain components to their latest upstream versions: GCC 14.2.1, Binutils 2.44, GDB 16.2, Newlib 4.4.0, LLVM 19.1.7, and GLIBC 2.40.
+
+- Support for the Zilsd and Zclsd extensions.
+
+- Some Nuclei custom CSR naming has been re-revised and corrected.
+
+- Implement custom VPU intrinsics for Nuclei RISC-V CPU.
+
+- Nuclei introduces the ``bf16`` type and supports the ``xxlvfbf`` and ``xxlfbf`` extensions.
+
+- Added support for 3-issue(``nuclei-1000-3w-series``) and 4-issue(``nuclei-1000-4w-series``) in the Nuclei 1000 series CPUs.
+
+- GCC14 introduces additional function attribute checks compared to GCC13. For more details, you can refer to https://gcc.gnu.org/gcc-14/porting_to.html.
+
+- Add the option to automatically generate control for Xldsp with ``-mautovec-dsp/-mno-autovec-dsp`` for gcc, which is enabled by default.
+
+- The ``riscv_vector.h`` must be included when leverage intrinisc type(s) and API(s).  And the scope of this attribute should not excced the function body.  Meanwhile, to make rvv types and API(s) available for this attribute, include ``riscv_vector.h`` will not report error for now if v is not present in march.
+
+- LLVM: Add Zilsd & Zclsd V1.0 assembly support
+
+- LLVM: Add Nuclei Xxldsp/Xxldspn1x/Xxldspn2x/Xxldspn3x extensions assembly support
+
+- LLVM: Add Nuclei Xxlcz extension assembly support
+
+- LLVM: Add Nuclei Xxlvamacc extension intrinsic support
+
+- LLVM: Update Nuclei custom csrs
+
+- LLVM: Update the multilib list
+
+.. _toolchain_changelog_202406:
+
+Version 2024.06
+---------------
+
+- Updated toolchain components to their latest upstream versions: GCC 13.1, Binutils 2.40, GDB 13.2, Newlib 4.3.0, LLVM 17.0.2, and GLIBC 2.38.
+
+- Instead of using single-letter ``bkp`` to enable these extensions as we did on gcc10, we split them all into corresponding sub-extensions, for example, ``_zba_zkr_zve32f``, please check https://doc.nucleisys.com/nuclei_sdk/develop/buildsystem.html#arch-ext to learn about how to adapt Nuclei SDK to support gcc13 upgraded from gcc10.
+
+- Implement new style of architecture extension test macros: each architecture extension has a corresponding feature test macro, which can be used to test its existence and version information. In addition, we add several custom macros, ``__riscv_dsp``, ``__riscv_bitmanip``.
+
+- Add new option ``-misa-spec=*`` to control ISA spec version. This controls the default version of each extensions. The official version is ``20191213``, but it is set to ``2.2`` when configuring nuclei toolchain.
+  The difference between them is that in ``20191213`` version, ``Zicsr`` and ``Zifencei`` are separated from the ``i`` extension into two independent extensions, and using ``-misa-spec=2.2`` can avoid incompatible errors when the ``Zicsr`` and ``Zifencei`` are not passed to ``-march=``. See for details at https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1315
+
+- Support for vector intrinsics as specified in version 0.12 of the RISC-V vector intrinsic specification.
+
+- The toolchain component prefix is ``riscv-nuclei-elf-`` on gcc10, but is ``riscv64-unknown-elf-`` on gcc13.
+
+- On gcc10, RISCV intrinsic api heads contain ``riscv_vector.h``, ``riscv_vector_itr.h``, ``rvintrin.h``, ``rvp_intrinsic.h``, but now only ``riscv_vector.h``, ``rvp_intrinsic.h``, ``riscv_nuclei_xlcz.h`` are provided in gcc13, if you want to find ``b`` or ``k`` intrinsic API, please check https://github.com/riscv/riscv-crypto/blob/main/benchmarks/share/rvintrin.h and https://github.com/riscv/riscv-crypto/blob/main/benchmarks/share/riscv-crypto-intrinsics.h , and for RVV intrinsic API, we
+  support 0.12 in gcc13 now, see https://github.com/riscv-non-isa/rvv-intrinsic-doc/releases/tag/v1.0-rc0
+
+- The version of the libncrt was changed from v2.0.0 to v3.0.0, and libncrt is now split into three parts, 'libncrt', 'heapops' and 'fileops', click https://doc.nucleisys.com/nuclei_sdk/develop/buildsystem.html#stdclib to learn about how the newlib/libncrt are used in Nuclei SDK with gcc13.
+

--- a/source/toolchain/changelog.rst
+++ b/source/toolchain/changelog.rst
@@ -73,7 +73,7 @@ Version 2025.02
 
 - Add the option to automatically generate control for Xldsp with ``-mautovec-dsp/-mno-autovec-dsp`` for gcc, which is enabled by default.
 
-- The ``riscv_vector.h`` must be included when leverage intrinisc type(s) and API(s).  And the scope of this attribute should not excced the function body.  Meanwhile, to make rvv types and API(s) available for this attribute, include ``riscv_vector.h`` will not report error for now if v is not present in march.
+- The ``riscv_vector.h`` must be included when leverage intrinsic type(s) and API(s).  And the scope of this attribute should not exceed the function body.  Meanwhile, to make rvv types and API(s) available for this attribute, include ``riscv_vector.h`` will not report error for now if v is not present in march.
 
 - LLVM: Add Zilsd & Zclsd V1.0 assembly support
 

--- a/source/toolchain/gnu/intro.rst
+++ b/source/toolchain/gnu/intro.rst
@@ -193,12 +193,13 @@ Libraries
 
     ``libncrt`` is short of **Nuclei C Runtime Library**, which currently support Nuclei RV32 processor, which is released by Nuclei to reduce c library code size, and improve math library speed, for details, please refer to the user guide located in ``gcc\share\pdf\Nuclei C Runtime Library Doc.pdf``
 
-.. _gnu_changelog_202406:
+Changelog
+=========
 
-Significant Changes Brought by GCC13 Compared to GCC10
-======================================================
+.. _llvm_changelog_202406:
 
-This is the changelog for 2023.10 and 2024.06.
+Version 2024.06
+---------------
 
 - Instead of using single-letter ``bkp`` to enable these extensions as we did on gcc10, we split them all into corresponding sub-extensions, for example, ``_zba_zkr_zve32f``, please check https://doc.nucleisys.com/nuclei_sdk/develop/buildsystem.html#arch-ext to learn about how to adapt Nuclei SDK to support gcc13 upgraded from gcc10.
 
@@ -217,14 +218,14 @@ This is the changelog for 2023.10 and 2024.06.
 - The version of the libncrt was changed from v2.0.0 to v3.0.0, and libncrt is now split into three parts, 'libncrt', 'heapops' and 'fileops', click https://doc.nucleisys.com/nuclei_sdk/develop/buildsystem.html#stdclib to learn about how the newlib/libncrt are used in Nuclei SDK with gcc13.
 
 
-.. _gnu_changelog_202502:
+.. _llvm_changelog_202502:
 
-Significant Changes Brought by GCC14 Compared to GCC13
-======================================================
+Version 2025.02
+---------------
 
-This is the changelog for 2025.02.
+- Updated toolchain components to their latest upstream versions: GCC 14.2.1, Binutils 2.44, GDB 16.2, Newlib 4.4.0, LLVM 19.1.7, and GLIBC 2.40.
 
-- Support for the zilsd and zclsd extensions.
+- Support for the Zilsd and Zclsd extensions.
 
 - Some Nuclei custom CSR naming has been re-revised and corrected.
 
@@ -236,35 +237,38 @@ This is the changelog for 2025.02.
 
 - GCC14 introduces additional function attribute checks compared to GCC13. For more details, you can refer to https://gcc.gnu.org/gcc-14/porting_to.html.
 
-- Add the option to automatically generate control for xldsp with ``-mautovec-dsp/-mno-autovec-dsp`` for gcc, which is enabled by default.
+- Add the option to automatically generate control for Xldsp with ``-mautovec-dsp/-mno-autovec-dsp`` for gcc, which is enabled by default.
 
 - The ``riscv_vector.h`` must be included when leverage intrinisc type(s) and API(s).  And the scope of this attribute should not excced the function body.  Meanwhile, to make rvv types and API(s) available for this attribute, include ``riscv_vector.h`` will not report error for now if v is not present in march.
 
-This is the changelog for 2025.10.
+.. _llvm_changelog_202510:
+
+Version 2025.10
+---------------
 
 - Feature: Windows newlib GCC now supports Win32_x64 (64-bit), replacing Win32 (32-bit).
 
-- Feature: Added auto-generation support for the zcmt extension.
+- Feature: Added auto-generation support for the Zcmt extension.
 
-- Feature: Initial support for ECLIC v2 instructions and CSRs added to binutils and GDB.
+- Feature: Initial support for ECLIC v2 instructions and CSRs added to Binutils and GDB.
 
 - Feature: Added multilib support for Zfinx, Zdinx, and related extensions.
 
-- Feature: binutils and GDB now add support for Virtual Supervisor-level CSRs.
+- Feature: Binutils and GDB now add support for Virtual Supervisor-level CSRs.
 
-- Feature: Add missing fcvt.d.h/fcvt.h.d instructions for xxlfbf extension.
+- Feature: Add missing fcvt.d.h/fcvt.h.d instructions for Xxlfbf extension.
 
 - Feature: Added Xxlvw extension support.
 
-- Feature: Add a new -maddibne/-mno-addibne option to control whether xxlcz's addibne instruction is auto-generated.
+- Feature: Add a new -maddibne/-mno-addibne option to control whether Xxlcz's addibne instruction is auto-generated.
 
-- Performance optimization: Aligned newlib memory/string routines (memcpy/memset/setjmp/strcmp/strcpy/strlen) to 4-byte boundaries.
+- Performance optimization: Aligned Newlib memory/string routines (memcpy/memset/setjmp/strcmp/strcpy/strlen) to 4-byte boundaries.
 
-- Fixed: Compilation issues with semihosting functions _times and _gettimeofday in newlib.
+- Fixed: Compilation issues with semihosting functions _times and _gettimeofday in Newlib.
 
-- Fixed: Incorrect inline assembly translation for the clrov instruction in xxldsp (binutils).
+- Fixed: Incorrect inline assembly translation for the clrov instruction in Xxldsp (Binutils).
 
-- Fixed: Conflicts between the xxlvfbf extension and zvfbfmin/zvfbfwma extensions.
+- Fixed: Conflicts between the Xxlvfbf extension and Zvfbfmin/Zvfbfwma extensions.
 
 - Fixed: Fix codegen regression in branch condition optimization by removing redundant AND -1 instruction.
 

--- a/source/toolchain/gnu/intro.rst
+++ b/source/toolchain/gnu/intro.rst
@@ -7,11 +7,11 @@ The official toolchain repository is located at https://github.com/riscv-collab/
 
 Nuclei maintained toolchain repo is located at https://github.com/riscv-mcu/riscv-gnu-toolchain.
 
-The latest release **2025.10** branch for gcc14 and llvm19 is ``nuclei/2025``, in which the tools included versions are: gcc 14.2.1, binutils 2.44, gdb 16.2, newlib 4.5.0, llvm 19.1.7, glibc 2.41, and also have merged some important patches from their upstream, as well as additional support for Nuclei custom extensions and pipelines, etc.
+The latest release **2025.10** branch for gcc14 and llvm19 is ``nuclei/2025.10``, in which the tools included versions are: gcc 14.2.1, binutils 2.44, gdb 16.2, newlib 4.5.0, llvm 19.1.7, glibc 2.41, and also have merged some important patches from their upstream, as well as additional support for Nuclei custom extensions and pipelines, etc.
 
 .. note::
 
-    The toolchain is implemented based on the upstream version. Many features can be referenced in the GCC online documentation: https://gcc.gnu.org/onlinedocs/. Additionally, local documentation is available under ``gcc/share/doc`` in the toolchain directory.
+    The toolchain is implemented based on the upstream version. Many features can be referenced in the GCC online documentation: https://gcc.gnu.org/onlinedocs/. Please check the corresponding GNU release version in the online documentation for accurate details. Additionally, local documentation is available under ``gcc/share/doc`` in the toolchain directory.
 
 Extensions Support
 ==================
@@ -198,9 +198,7 @@ Libraries
 Changelog
 =========
 
-.. note::
-
-    Please check :ref:`toolchain_changelog` here.
+    Please check :ref:`Changelog <toolchain_changelog>` here.
 
 Install and Setup
 =================
@@ -224,7 +222,7 @@ and for the 'heapops', you must select one of the three options: 'basic', 'realt
 
 
 Checking GNU Version
---------------------
+====================
 
 To check the basic version information of GCC, you can use the command ``riscv64-unknown-elf-gcc -v``.
 

--- a/source/toolchain/gnu/intro.rst
+++ b/source/toolchain/gnu/intro.rst
@@ -9,7 +9,9 @@ Nuclei maintained toolchain repo is located at https://github.com/riscv-mcu/risc
 
 The latest release **2025.10** branch for gcc14 and llvm19 is ``nuclei/2025``, in which the tools included versions are: gcc 14.2.1, binutils 2.44, gdb 16.2, newlib 4.5.0, llvm 19.1.7, glibc 2.41, and also have merged some important patches from their upstream, as well as additional support for Nuclei custom extensions and pipelines, etc.
 
-For the 2024.06 toolchain branch(gcc13 + llvm17), you can check out the ``nuclei/2024-gcc13`` branch.
+.. note::
+
+    The toolchain is implemented based on the upstream version. Many features can be referenced in the GCC online documentation: https://gcc.gnu.org/onlinedocs/. Additionally, local documentation is available under ``gcc/share/doc`` in the toolchain directory.
 
 Extensions Support
 ==================
@@ -196,83 +198,9 @@ Libraries
 Changelog
 =========
 
-.. _llvm_changelog_202406:
+.. note::
 
-Version 2024.06
----------------
-
-- Instead of using single-letter ``bkp`` to enable these extensions as we did on gcc10, we split them all into corresponding sub-extensions, for example, ``_zba_zkr_zve32f``, please check https://doc.nucleisys.com/nuclei_sdk/develop/buildsystem.html#arch-ext to learn about how to adapt Nuclei SDK to support gcc13 upgraded from gcc10.
-
-- Implement new style of architecture extension test macros: each architecture extension has a corresponding feature test macro, which can be used to test its existence and version information. In addition, we add several custom macros, ``__riscv_dsp``, ``__riscv_bitmanip``.
-
-- Add new option ``-misa-spec=*`` to control ISA spec version. This controls the default version of each extensions. The official version is ``20191213``, but it is set to ``2.2`` when configuring nuclei toolchain.
-  The difference between them is that in ``20191213`` version, ``Zicsr`` and ``Zifencei`` are separated from the ``i`` extension into two independent extensions, and using ``-misa-spec=2.2`` can avoid incompatible errors when the ``Zicsr`` and ``Zifencei`` are not passed to ``-march=``. See for details at https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1315
-
-- Support for vector intrinsics as specified in version 0.12 of the RISC-V vector intrinsic specification.
-
-- The toolchain component prefix is ``riscv-nuclei-elf-`` on gcc10, but is ``riscv64-unknown-elf-`` on gcc13.
-
-- On gcc10, RISCV intrinsic api heads contain ``riscv_vector.h``, ``riscv_vector_itr.h``, ``rvintrin.h``, ``rvp_intrinsic.h``, but now only ``riscv_vector.h``, ``rvp_intrinsic.h``, ``riscv_nuclei_xlcz.h`` are provided in gcc13, if you want to find ``b`` or ``k`` intrinsic API, please check https://github.com/riscv/riscv-crypto/blob/main/benchmarks/share/rvintrin.h and https://github.com/riscv/riscv-crypto/blob/main/benchmarks/share/riscv-crypto-intrinsics.h , and for RVV intrinsic API, we
-  support 0.12 in gcc13 now, see https://github.com/riscv-non-isa/rvv-intrinsic-doc/releases/tag/v1.0-rc0
-
-- The version of the libncrt was changed from v2.0.0 to v3.0.0, and libncrt is now split into three parts, 'libncrt', 'heapops' and 'fileops', click https://doc.nucleisys.com/nuclei_sdk/develop/buildsystem.html#stdclib to learn about how the newlib/libncrt are used in Nuclei SDK with gcc13.
-
-
-.. _llvm_changelog_202502:
-
-Version 2025.02
----------------
-
-- Updated toolchain components to their latest upstream versions: GCC 14.2.1, Binutils 2.44, GDB 16.2, Newlib 4.4.0, LLVM 19.1.7, and GLIBC 2.40.
-
-- Support for the Zilsd and Zclsd extensions.
-
-- Some Nuclei custom CSR naming has been re-revised and corrected.
-
-- Implement custom VPU intrinsics for Nuclei RISC-V CPU.
-
-- Nuclei introduces the ``bf16`` type and supports the ``xxlvfbf`` and ``xxlfbf`` extensions.
-
-- Added support for 3-issue(``nuclei-1000-3w-series``) and 4-issue(``nuclei-1000-4w-series``) in the Nuclei 1000 series CPUs.
-
-- GCC14 introduces additional function attribute checks compared to GCC13. For more details, you can refer to https://gcc.gnu.org/gcc-14/porting_to.html.
-
-- Add the option to automatically generate control for Xldsp with ``-mautovec-dsp/-mno-autovec-dsp`` for gcc, which is enabled by default.
-
-- The ``riscv_vector.h`` must be included when leverage intrinisc type(s) and API(s).  And the scope of this attribute should not excced the function body.  Meanwhile, to make rvv types and API(s) available for this attribute, include ``riscv_vector.h`` will not report error for now if v is not present in march.
-
-.. _llvm_changelog_202510:
-
-Version 2025.10
----------------
-
-- Feature: Windows newlib GCC now supports Win32_x64 (64-bit), replacing Win32 (32-bit).
-
-- Feature: Added auto-generation support for the Zcmt extension.
-
-- Feature: Initial support for ECLIC v2 instructions and CSRs added to Binutils and GDB.
-
-- Feature: Added multilib support for Zfinx, Zdinx, and related extensions.
-
-- Feature: Binutils and GDB now add support for Virtual Supervisor-level CSRs.
-
-- Feature: Add missing fcvt.d.h/fcvt.h.d instructions for Xxlfbf extension.
-
-- Feature: Added Xxlvw extension support.
-
-- Feature: Add a new -maddibne/-mno-addibne option to control whether Xxlcz's addibne instruction is auto-generated.
-
-- Performance optimization: Aligned Newlib memory/string routines (memcpy/memset/setjmp/strcmp/strcpy/strlen) to 4-byte boundaries.
-
-- Fixed: Compilation issues with semihosting functions _times and _gettimeofday in Newlib.
-
-- Fixed: Incorrect inline assembly translation for the clrov instruction in Xxldsp (Binutils).
-
-- Fixed: Conflicts between the Xxlvfbf extension and Zvfbfmin/Zvfbfwma extensions.
-
-- Fixed: Fix codegen regression in branch condition optimization by removing redundant AND -1 instruction.
-
-- Fixed: Fix unnecessary slli/srai instruction generation when using int16 type.
+    Please check :ref:`toolchain_changelog` here.
 
 Install and Setup
 =================
@@ -293,3 +221,40 @@ The process of user compilation and development can see from https://github.com/
 
 3. When using a library, we can tell the linker which library we need to link by using the '-l', for example, ``-lc`` for newlib-full, ``-lc_nano`` for newlib-nano. For libncrt, you should pass ``--specs=libncrt_xxx.specs`` when using gcc. In addition, you need to link extra 'fileops' and 'heapops' static libraries during the linking phase by using the '-l', and for the 'fileops', you must select one of the three options: 'uart', 'semi' or 'rtt',
 and for the 'heapops', you must select one of the three options: 'basic', 'realtime' or 'minimal'.
+
+
+Checking GNU Version
+--------------------
+
+To check the basic version information of GCC, you can use the command ``riscv64-unknown-elf-gcc -v``.
+
+If you need to report an issue to the developers, please provide:
+
+1.The ``gcc/build.txt`` file (located in the GCC directory) for GCC compilation details.
+
+2.The ``gcc/gitrepo.txt`` file to confirm commit IDs of each tool, which helps determine more detailed build information.
+
+Known Issues
+============
+
+``sscanf`` Format Specifiers Issue in Newlib-nano
+-------------------------------------------------
+
+sscanf fails with hhu, llu, etc., due to missing C99 support (%hhX, %llX, %jX, %zX, %tX).
+
+References:
+
+- https://docs.zephyrproject.org/latest/develop/languages/c/newlib.html
+
+- https://github.com/32bitmicro/newlib-nano-1.0/blob/master/newlib/README.nano
+
+
+GDB RISC-V Memory Access at Address 0 When Symbols Are Missing
+--------------------------------------------------------------
+
+When debugging a RISC-V target via OpenOCD+GDB, running a stepping command (si) before loading an ELF with symbols causes GDB to incorrectly read memory near address 0x0.
+
+References:
+
+- https://github.com/riscv-mcu/riscv-openocd/issues/16
+

--- a/source/toolchain/gnu/intro.rst
+++ b/source/toolchain/gnu/intro.rst
@@ -7,7 +7,7 @@ The official toolchain repository is located at https://github.com/riscv-collab/
 
 Nuclei maintained toolchain repo is located at https://github.com/riscv-mcu/riscv-gnu-toolchain.
 
-The latest release **2025.02** branch for gcc14 and llvm19 is ``nuclei/2025.02``, in which the tools included versions are: gcc 14.2.1, binutils 2.44, gdb 16.2, newlib 4.4.0, llvm 19.1.7, glibc 2.40, and also have merged some important patches from their upstream, as well as additional support for Nuclei custom extensions and pipelines, etc.
+The latest release **2025.10** branch for gcc14 and llvm19 is ``nuclei/2025``, in which the tools included versions are: gcc 14.2.1, binutils 2.44, gdb 16.2, newlib 4.5.0, llvm 19.1.7, glibc 2.41, and also have merged some important patches from their upstream, as well as additional support for Nuclei custom extensions and pipelines, etc.
 
 For the 2024.06 toolchain branch(gcc13 + llvm17), you can check out the ``nuclei/2024-gcc13`` branch.
 
@@ -42,7 +42,7 @@ Extensions Support
 
 - Zc Extensions
 
-    zca, zcb, zce, zcf, zcd, zcmp, zcmt(Assembly only).
+    zca, zcb, zce, zcf, zcd, zcmp, zcmt.
 
     - zce = zca + zcb + zcmp + zcmt
     - f + zce =  zca + zcb + zcf + zcmp + zcmt
@@ -127,6 +127,10 @@ General Options
 `-mautovec-dsp/-mno-autovec-dsp`
 
     Controls the generation of automatic vectorization of Nuclei DSP instructions, with the compiler enabling Nuclei DSP instructions instruction auto-vectorization by default.
+
+`-maddibne/-mno-addibne`
+
+    Controls auto-generation of the ``addibne`` instruction for the ``xxlcz`` extension. Enabled by default.
 
 `-fstrict-aliasing`
 
@@ -236,16 +240,46 @@ This is the changelog for 2025.02.
 
 - The ``riscv_vector.h`` must be included when leverage intrinisc type(s) and API(s).  And the scope of this attribute should not excced the function body.  Meanwhile, to make rvv types and API(s) available for this attribute, include ``riscv_vector.h`` will not report error for now if v is not present in march.
 
+This is the changelog for 2025.10.
+
+- Feature: Windows newlib GCC now supports Win32_x64 (64-bit), replacing Win32 (32-bit).
+
+- Feature: Added auto-generation support for the zcmt extension.
+
+- Feature: Initial support for ECLIC v2 instructions and CSRs added to binutils and GDB.
+
+- Feature: Added multilib support for Zfinx, Zdinx, and related extensions.
+
+- Feature: binutils and GDB now add support for Virtual Supervisor-level CSRs.
+
+- Feature: Add missing fcvt.d.h/fcvt.h.d instructions for xxlfbf extension.
+
+- Feature: Added Xxlvw extension support.
+
+- Feature: Add a new -maddibne/-mno-addibne option to control whether xxlcz's addibne instruction is auto-generated.
+
+- Performance optimization: Aligned newlib memory/string routines (memcpy/memset/setjmp/strcmp/strcpy/strlen) to 4-byte boundaries.
+
+- Fixed: Compilation issues with semihosting functions _times and _gettimeofday in newlib.
+
+- Fixed: Incorrect inline assembly translation for the clrov instruction in xxldsp (binutils).
+
+- Fixed: Conflicts between the xxlvfbf extension and zvfbfmin/zvfbfwma extensions.
+
+- Fixed: Fix codegen regression in branch condition optimization by removing redundant AND -1 instruction.
+
+- Fixed: Fix unnecessary slli/srai instruction generation when using int16 type.
+
 Install and Setup
 =================
 
 .. rubric:: Build Toolchain
 
-For more information about how to build a toolchain, see https://github.com/riscv-mcu/riscv-gnu-toolchain/tree/nuclei/2025.02/scripts/toolchain. (Only for Nuclei internal use, no technical support is provided)
+For more information about how to build a toolchain, see https://github.com/riscv-mcu/riscv-gnu-toolchain/tree/nuclei/2025/scripts/toolchain. (Only for Nuclei internal use, no technical support is provided)
 
 .. rubric:: Development
 
-The process of user compilation and development can see from https://github.com/riscv-mcu/riscv-gnu-toolchain/blob/nuclei/2025.02/README.md. To get other technical support, please send issues directly to the upstream repository https://github.com/riscv-collab/riscv-gnu-toolchain.
+The process of user compilation and development can see from https://github.com/riscv-mcu/riscv-gnu-toolchain/blob/nuclei/2025/README.md. To get other technical support, please send issues directly to the upstream repository https://github.com/riscv-collab/riscv-gnu-toolchain.
 
 .. rubric:: Examples
 

--- a/source/toolchain/gnu/intro.rst
+++ b/source/toolchain/gnu/intro.rst
@@ -230,9 +230,9 @@ To check the basic version information of GCC, you can use the command ``riscv64
 
 If you need to report an issue to the developers, please provide:
 
-1.The ``gcc/build.txt`` file (located in the GCC directory) for GCC compilation details.
+1. The ``gcc/build.txt`` file (located in the GCC directory) for GCC compilation details.
 
-2.The ``gcc/gitrepo.txt`` file to confirm commit IDs of each tool, which helps determine more detailed build information.
+2. The ``gcc/gitrepo.txt`` file to confirm commit IDs of each tool, which helps determine more detailed build information.
 
 Known Issues
 ============

--- a/source/toolchain/index.rst
+++ b/source/toolchain/index.rst
@@ -9,3 +9,4 @@ Nuclei Toolchain
 
    gnu/index.rst
    llvm/index.rst
+   changelog.rst

--- a/source/toolchain/llvm/intro.rst
+++ b/source/toolchain/llvm/intro.rst
@@ -140,3 +140,14 @@ Version 2025.02
 - Add Nuclei Xxlvamacc extension intrinsic support
 - Update Nuclei custom csrs
 - Update the multilib list
+
+
+.. _llvm_changelog_202510:
+
+Version 2025.10
+---------------
+
+- Initial implementation of pipeline support for Nuclei processor 100/200/300/600/900/1000 series.
+- Added scalar BFloat16 support for Nuclei processors.
+- Implemented Nuclei-specific VPU matrix instructions.
+- Added missing Virtual Supervisor-level CSRs (hedelegh/medelegh) support in LLVM

--- a/source/toolchain/llvm/intro.rst
+++ b/source/toolchain/llvm/intro.rst
@@ -7,6 +7,10 @@ The current llvm toolchain is developed based on the upstream V19.1.7, for exten
 
 You can find our llvm source code in https://github.com/riscv-mcu/llvm-project/tree/nuclei/19.x
 
+.. note::
+
+    The LLVM is implemented based on the upstream version. Many features can be referenced in the official LLVM documentation: https://llvm.org/docs/. Local documentation is also available under ``gcc/share/doc`` within the toolchain directory.
+
 Extensions Support
 ==================
 
@@ -128,26 +132,17 @@ More information on building and running LLVM, see https://llvm.org/docs/Getting
 Changelog
 =========
 
-.. _llvm_changelog_202502:
+.. note::
 
-Version 2025.02
----------------
+    Please check :ref:`toolchain_changelog` here.
 
-- llvm was upgraded to the upstream version 19.1.7
-- Add Zilsd & Zclsd V1.0 assembly support
-- Add Nuclei Xxldsp/Xxldspn1x/Xxldspn2x/Xxldspn3x extensions assembly support
-- Add Nuclei Xxlcz extension assembly support
-- Add Nuclei Xxlvamacc extension intrinsic support
-- Update Nuclei custom csrs
-- Update the multilib list
+Checking GNU Version
+--------------------
 
+To check the basic version information of Clang, you can use the command ``riscv64-unknown-elf-clang -v``.
 
-.. _llvm_changelog_202510:
+If you need to report an issue to the developers, please provide:
 
-Version 2025.10
----------------
+1.The ``gcc/build.txt`` file (located in the GCC directory) for GCC compilation details.
 
-- Initial implementation of pipeline support for Nuclei processor 100/200/300/600/900/1000 series.
-- Added scalar BFloat16 support for Nuclei processors.
-- Implemented Nuclei-specific VPU matrix instructions.
-- Added missing Virtual Supervisor-level CSRs (hedelegh/medelegh) support in LLVM
+2.The ``gcc/gitrepo.txt`` file to confirm commit IDs of each tool, which helps determine more detailed build information.

--- a/source/toolchain/llvm/intro.rst
+++ b/source/toolchain/llvm/intro.rst
@@ -9,7 +9,7 @@ You can find our llvm source code in https://github.com/riscv-mcu/llvm-project/t
 
 .. note::
 
-    The LLVM is implemented based on the upstream version. Many features can be referenced in the official LLVM documentation: https://llvm.org/docs/. Local documentation is also available under ``gcc/share/doc`` within the toolchain directory.
+    The LLVM toolchain is implemented based on the upstream version. Many features can be referenced in the official LLVM documentation: https://llvm.org/docs/. Please refer to the corresponding LLVM release version in the documentation for accurate details. Local documentation is also available under ``gcc/share/doc/llvm/docs/html`` within the toolchain directory.
 
 Extensions Support
 ==================
@@ -132,14 +132,12 @@ More information on building and running LLVM, see https://llvm.org/docs/Getting
 Changelog
 =========
 
-.. note::
+    Please check :ref:`Changelog <toolchain_changelog>` here.
 
-    Please check :ref:`toolchain_changelog` here.
+Checking LLVM Version
+=====================
 
-Checking Clang Version
-----------------------
-
-To check the basic version information of Clang, you can use the command ``riscv64-unknown-elf-clang -v``.
+To check the basic version information of LLVM, you can use the command ``riscv64-unknown-elf-clang -v``.
 
 If you need to report an issue to the developers, please provide:
 

--- a/source/toolchain/llvm/intro.rst
+++ b/source/toolchain/llvm/intro.rst
@@ -136,13 +136,13 @@ Changelog
 
     Please check :ref:`toolchain_changelog` here.
 
-Checking GNU Version
---------------------
+Checking Clang Version
+----------------------
 
 To check the basic version information of Clang, you can use the command ``riscv64-unknown-elf-clang -v``.
 
 If you need to report an issue to the developers, please provide:
 
-1.The ``gcc/build.txt`` file (located in the GCC directory) for GCC compilation details.
+1. The ``gcc/build.txt`` file (located in the GCC directory) for GCC compilation details.
 
-2.The ``gcc/gitrepo.txt`` file to confirm commit IDs of each tool, which helps determine more detailed build information.
+2. The ``gcc/gitrepo.txt`` file to confirm commit IDs of each tool, which helps determine more detailed build information.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update GNU and LLVM toolchain documentation for 2025.10 release with new features, optimizations, and fixes.
> 
>   - **Changelog**:
>     - Added `changelog.rst` with updates for versions 2025.10, 2025.02, and 2024.06.
>     - Updated toolchain components to latest versions in 2025.10: GCC 14.2.1, Binutils 2.44, GDB 16.2, Newlib 4.5.0, LLVM 19.1.7, GLIBC 2.41.
>     - Added features like Win32_x64 support, `Zcmt` extension, `ECLIC v2` instructions, and multilib support for `Zfinx`, `Zdinx`.
>     - Performance optimizations and fixes for Newlib and Binutils.
>     - LLVM updates include pipeline support for Nuclei processors and BFloat16 support.
>   - **GNU Toolchain**:
>     - Updated `intro.rst` to reflect 2025.10 release with new tool versions and features.
>     - Added notes on toolchain implementation and documentation references.
>     - Updated extensions and general options sections.
>   - **LLVM Toolchain**:
>     - Updated `intro.rst` to include notes on LLVM toolchain implementation and documentation.
>     - Updated extensions support and general options sections.
>   - **Misc**:
>     - Added `changelog.rst` to `index.rst`.
>     - Updated installation and setup instructions in both GNU and LLVM documentation.
>     - Added sections for checking toolchain versions and known issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for 0e80342f5664408294372f4a6fec2bf23ca5aa6e. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->