### PR TITLE
doc: Update qemu doc with guidance for upstream doc and version infor…

### DIFF
--- a/source/qemu/intro.rst
+++ b/source/qemu/intro.rst
@@ -17,8 +17,19 @@ Nuclei QEMU is now developed based on QEMU version 9.0, supporting the machine f
 
   - **Xxlfbf & Xxlvfbf**: Nuclei custom scalar & vector BF16 extensions
 
-If you want to access the code of Nuclei QEMU, you can visit our opensource `Nuclei QEMU Github Repository <https://github.com/riscv-mcu/qemu/tree/nuclei/9.0>`_.
+.. note::
 
+  Before using Nuclei QEMU, you can check the current version on which Nuclei QEMU is based and the commit id through the ``--version`` option of Nuclei QEMU, for example:
+
+  .. code-block:: shell
+
+    $ qemu-system-riscv32 --version
+    QEMU emulator version 9.0.4 (v9.0.4-143-g1857be8c7d-dirty)
+    Copyright (c) 2003-2024 Fabrice Bellard and the QEMU Project developers
+
+  The above shows that Nuclei QEMU is currently developed based on the upstream version 9.0.4, and commit id is `1857be8c7d <https://github.com/riscv-mcu/qemu/tree/1857be8c7d>`_.
+
+If you want to access the code of Nuclei QEMU, you can visit our opensource `Nuclei QEMU Github Repository <https://github.com/riscv-mcu/qemu/tree/nuclei/9.0>`_. If you want to learn more about QEMU, please refer to the official QEMU documentation, which is available at https://www.qemu.org/documentation/.
 
 Design and Architecture
 =======================


### PR DESCRIPTION
…mation
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `intro.rst` to guide users on checking Nuclei QEMU version and commit ID, and link to official QEMU docs.
> 
>   - **Documentation**:
>     - Adds guidance in `intro.rst` for checking Nuclei QEMU version and commit ID using `--version` option.
>     - Updates `intro.rst` to include a link to the official QEMU documentation for further information.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for cd63693d58a3a06bd1500644eed6dcc360cc854b. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->