### PR TITLE
doc: update llvm changelog for 2025.10 release

### DIFF
--- a/source/toolchain/changelog.rst
+++ b/source/toolchain/changelog.rst
@@ -52,6 +52,12 @@ Version 2025.10
 
 - LLVM: Added missing ``Virtual Supervisor-level`` CSRs (hedelegh/medelegh) support in LLVM
 
+- LLVM: Added Nuclei custom macro ``__riscv_dsp``, which can be used instead of ``__riscv_xxldsp`` in the old version.
+
+- LLVM: Added missing instructions ``dkabs32``, ``dsma32.u``, ``clrov``, ``rdov``, ``kmada32``, and ``smbb32``.
+
+- LLVM: Fixed the issue where the Xxldsp extension could not be disassembled correctly.
+
 .. _toolchain_changelog_202502:
 
 Version 2025.02


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update LLVM changelog for 2025.10 release with new macro, instructions, and a disassembly fix.
> 
>   - **LLVM Features**:
>     - Added Nuclei custom macro `__riscv_dsp` as an alternative to `__riscv_xxldsp`.
>     - Added missing instructions: `dkabs32`, `dsma32.u`, `clrov`, `rdov`, `kmada32`, `smbb32`.
>   - **LLVM Fixes**:
>     - Fixed disassembly issue with the Xxldsp extension.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for 33d861e58fe9acb67097d69c882bd1d150fc186b. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->