### PR TITLE
修复一下文档中存在的错误

### DIFF
--- a/source/openocd/intro.rst
+++ b/source/openocd/intro.rst
@@ -584,4 +584,5 @@ CSR Renaming:
 **Base Version:**
 
 - Changes based on `riscv-collab/riscv-openocd@f82c5a7 <https://github.com/riscv-collab/riscv-openocd/commit/f82c5a7>`_.
-.. cpuinfo: https://doc.nucleisys.com/nuclei_sdk/design/app.html#cpuinfo
+
+.. _cpuinfo: https://doc.nucleisys.com/nuclei_sdk/design/app.html#cpuinfo

--- a/source/toolchain/gnu/nuclei_bf16.rst
+++ b/source/toolchain/gnu/nuclei_bf16.rst
@@ -55,6 +55,7 @@ Nuclei bf16 标量的运算操作,需要开启 ``xxlfbf`` 扩展.
 * ``fmadd.h/fmsub.h/fnmadd.h/fnmsub.h``
 * ``fsqrt.h``
 * ``fcvt.bf16.s/fcvt.s.bf16`` (兼容zfbfmin扩展的指令)
+* ``fcvt.h.d/fcvt.d.h`` (2025.10 版本补充)
 * ``fcvt.h.w[u]/fcvt.w[u].h`` (int32 <---> bf16)
 * ``fcvt.h.l[u]/fcvt.l[u].h`` (int64 <---> bf16)
 * ``fmin.h/fmax.h``

--- a/source/toolchain/gnu/nuclei_xxlvw.rst
+++ b/source/toolchain/gnu/nuclei_xxlvw.rst
@@ -139,47 +139,47 @@ Nuclei 自定义的 intrinsic
 
 .. code-block:: c
 
-    vint8mf8_t __riscv_xl_vdscmul_vv_i8mf8(vint8mf8_t vs2, vint8mf8_t vs1, size_t vl);
-    vint8mf4_t __riscv_xl_vdscmul_vv_i8mf4(vint8mf4_t vs2, vint8mf4_t vs1, size_t vl);
-    vint8mf2_t __riscv_xl_vdscmul_vv_i8mf2(vint8mf2_t vs2, vint8mf2_t vs1, size_t vl);
-    vint8m1_t __riscv_xl_vdscmul_vv_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl);
-    vint8m2_t __riscv_xl_vdscmul_vv_i8m2(vint8m2_t vs2, vint8m2_t vs1, size_t vl);
-    vint8m4_t __riscv_xl_vdscmul_vv_i8m4(vint8m4_t vs2, vint8m4_t vs1, size_t vl);
-    vint8m8_t __riscv_xl_vdscmul_vv_i8m8(vint8m8_t vs2, vint8m8_t vs1, size_t vl);
-    vint16mf4_t __riscv_xl_vdscmul_vv_i16mf4(vint16mf4_t vs2, vint16mf4_t vs1, size_t vl);
-    vint16mf2_t __riscv_xl_vdscmul_vv_i16mf2(vint16mf2_t vs2, vint16mf2_t vs1, size_t vl);
-    vint16m1_t __riscv_xl_vdscmul_vv_i16m1(vint16m1_t vs2, vint16m1_t vs1, size_t vl);
-    vint16m2_t __riscv_xl_vdscmul_vv_i16m2(vint16m2_t vs2, vint16m2_t vs1, size_t vl);
-    vint16m4_t __riscv_xl_vdscmul_vv_i16m4(vint16m4_t vs2, vint16m4_t vs1, size_t vl);
-    vint16m8_t __riscv_xl_vdscmul_vv_i16m8(vint16m8_t vs2, vint16m8_t vs1, size_t vl);
-    vint32mf2_t __riscv_xl_vdscmul_vv_i32mf2(vint32mf2_t vs2, vint32mf2_t vs1, size_t vl);
-    vint32m1_t __riscv_xl_vdscmul_vv_i32m1(vint32m1_t vs2, vint32m1_t vs1, size_t vl);
-    vint32m2_t __riscv_xl_vdscmul_vv_i32m2(vint32m2_t vs2, vint32m2_t vs1, size_t vl);
-    vint32m4_t __riscv_xl_vdscmul_vv_i32m4(vint32m4_t vs2, vint32m4_t vs1, size_t vl);
-    vint32m8_t __riscv_xl_vdscmul_vv_i32m8(vint32m8_t vs2, vint32m8_t vs1, size_t vl);
+    vint8mf8_t __riscv_xl_vdsmul_vv_i8mf8(vint8mf8_t vs2, vint8mf8_t vs1, size_t vl);
+    vint8mf4_t __riscv_xl_vdsmul_vv_i8mf4(vint8mf4_t vs2, vint8mf4_t vs1, size_t vl);
+    vint8mf2_t __riscv_xl_vdsmul_vv_i8mf2(vint8mf2_t vs2, vint8mf2_t vs1, size_t vl);
+    vint8m1_t __riscv_xl_vdsmul_vv_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl);
+    vint8m2_t __riscv_xl_vdsmul_vv_i8m2(vint8m2_t vs2, vint8m2_t vs1, size_t vl);
+    vint8m4_t __riscv_xl_vdsmul_vv_i8m4(vint8m4_t vs2, vint8m4_t vs1, size_t vl);
+    vint8m8_t __riscv_xl_vdsmul_vv_i8m8(vint8m8_t vs2, vint8m8_t vs1, size_t vl);
+    vint16mf4_t __riscv_xl_vdsmul_vv_i16mf4(vint16mf4_t vs2, vint16mf4_t vs1, size_t vl);
+    vint16mf2_t __riscv_xl_vdsmul_vv_i16mf2(vint16mf2_t vs2, vint16mf2_t vs1, size_t vl);
+    vint16m1_t __riscv_xl_vdsmul_vv_i16m1(vint16m1_t vs2, vint16m1_t vs1, size_t vl);
+    vint16m2_t __riscv_xl_vdsmul_vv_i16m2(vint16m2_t vs2, vint16m2_t vs1, size_t vl);
+    vint16m4_t __riscv_xl_vdsmul_vv_i16m4(vint16m4_t vs2, vint16m4_t vs1, size_t vl);
+    vint16m8_t __riscv_xl_vdsmul_vv_i16m8(vint16m8_t vs2, vint16m8_t vs1, size_t vl);
+    vint32mf2_t __riscv_xl_vdsmul_vv_i32mf2(vint32mf2_t vs2, vint32mf2_t vs1, size_t vl);
+    vint32m1_t __riscv_xl_vdsmul_vv_i32m1(vint32m1_t vs2, vint32m1_t vs1, size_t vl);
+    vint32m2_t __riscv_xl_vdsmul_vv_i32m2(vint32m2_t vs2, vint32m2_t vs1, size_t vl);
+    vint32m4_t __riscv_xl_vdsmul_vv_i32m4(vint32m4_t vs2, vint32m4_t vs1, size_t vl);
+    vint32m8_t __riscv_xl_vdsmul_vv_i32m8(vint32m8_t vs2, vint32m8_t vs1, size_t vl);
 
 * ``vdsmul.vs`` sew = 8/16/32  full_preds
 
 .. code-block:: c
 
-    vint8mf8_t __riscv_xl_vdscmul_vs_i8mf8_i8mf8(vint8mf8_t vs2, vint8mf8_t vs1, size_t vl);
-    vint8mf4_t __riscv_xl_vdscmul_vs_i8mf4_i8mf4(vint8mf4_t vs2, vint8mf4_t vs1, size_t vl);
-    vint8mf2_t __riscv_xl_vdscmul_vs_i8mf2_i8mf2(vint8mf2_t vs2, vint8mf2_t vs1, size_t vl);
-    vint8m1_t __riscv_xl_vdscmul_vs_i8m1_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl);
-    vint8m2_t __riscv_xl_vdscmul_vs_i8m2_i8m2(vint8m2_t vs2, vint8m2_t vs1, size_t vl);
-    vint8m4_t __riscv_xl_vdscmul_vs_i8m4_i8m4(vint8m4_t vs2, vint8m4_t vs1, size_t vl);
-    vint8m8_t __riscv_xl_vdscmul_vs_i8m8_i8m8(vint8m8_t vs2, vint8m8_t vs1, size_t vl);
-    vint16mf4_t __riscv_xl_vdscmul_vs_i16mf4_i16mf4(vint16mf4_t vs2, vint16mf4_t vs1, size_t vl);
-    vint16mf2_t __riscv_xl_vdscmul_vs_i16mf2_i16mf2(vint16mf2_t vs2, vint16mf2_t vs1, size_t vl);
-    vint16m1_t __riscv_xl_vdscmul_vs_i16m1_i16m1(vint16m1_t vs2, vint16m1_t vs1, size_t vl);
-    vint16m2_t __riscv_xl_vdscmul_vs_i16m2_i16m2(vint16m2_t vs2, vint16m2_t vs1, size_t vl);
-    vint16m4_t __riscv_xl_vdscmul_vs_i16m4_i16m4(vint16m4_t vs2, vint16m4_t vs1, size_t vl);
-    vint16m8_t __riscv_xl_vdscmul_vs_i16m8_i16m8(vint16m8_t vs2, vint16m8_t vs1, size_t vl);
-    vint32mf2_t __riscv_xl_vdscmul_vs_i32mf2_i32mf2(vint32mf2_t vs2, vint32mf2_t vs1, size_t vl);
-    vint32m1_t __riscv_xl_vdscmul_vs_i32m1_i32m1(vint32m1_t vs2, vint32m1_t vs1, size_t vl);
-    vint32m2_t __riscv_xl_vdscmul_vs_i32m2_i32m2(vint32m2_t vs2, vint32m2_t vs1, size_t vl);
-    vint32m4_t __riscv_xl_vdscmul_vs_i32m4_i32m4(vint32m4_t vs2, vint32m4_t vs1, size_t vl);
-    vint32m8_t __riscv_xl_vdscmul_vs_i32m8_i32m8(vint32m8_t vs2, vint32m8_t vs1, size_t vl);
+    vint8mf8_t __riscv_xl_vdsmul_vs_i8mf8_i8mf8(vint8mf8_t vs2, vint8mf8_t vs1, size_t vl);
+    vint8mf4_t __riscv_xl_vdsmul_vs_i8mf4_i8mf4(vint8mf4_t vs2, vint8mf4_t vs1, size_t vl);
+    vint8mf2_t __riscv_xl_vdsmul_vs_i8mf2_i8mf2(vint8mf2_t vs2, vint8mf2_t vs1, size_t vl);
+    vint8m1_t __riscv_xl_vdsmul_vs_i8m1_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl);
+    vint8m2_t __riscv_xl_vdsmul_vs_i8m2_i8m2(vint8m2_t vs2, vint8m2_t vs1, size_t vl);
+    vint8m4_t __riscv_xl_vdsmul_vs_i8m4_i8m4(vint8m4_t vs2, vint8m4_t vs1, size_t vl);
+    vint8m8_t __riscv_xl_vdsmul_vs_i8m8_i8m8(vint8m8_t vs2, vint8m8_t vs1, size_t vl);
+    vint16mf4_t __riscv_xl_vdsmul_vs_i16mf4_i16mf4(vint16mf4_t vs2, vint16mf4_t vs1, size_t vl);
+    vint16mf2_t __riscv_xl_vdsmul_vs_i16mf2_i16mf2(vint16mf2_t vs2, vint16mf2_t vs1, size_t vl);
+    vint16m1_t __riscv_xl_vdsmul_vs_i16m1_i16m1(vint16m1_t vs2, vint16m1_t vs1, size_t vl);
+    vint16m2_t __riscv_xl_vdsmul_vs_i16m2_i16m2(vint16m2_t vs2, vint16m2_t vs1, size_t vl);
+    vint16m4_t __riscv_xl_vdsmul_vs_i16m4_i16m4(vint16m4_t vs2, vint16m4_t vs1, size_t vl);
+    vint16m8_t __riscv_xl_vdsmul_vs_i16m8_i16m8(vint16m8_t vs2, vint16m8_t vs1, size_t vl);
+    vint32mf2_t __riscv_xl_vdsmul_vs_i32mf2_i32mf2(vint32mf2_t vs2, vint32mf2_t vs1, size_t vl);
+    vint32m1_t __riscv_xl_vdsmul_vs_i32m1_i32m1(vint32m1_t vs2, vint32m1_t vs1, size_t vl);
+    vint32m2_t __riscv_xl_vdsmul_vs_i32m2_i32m2(vint32m2_t vs2, vint32m2_t vs1, size_t vl);
+    vint32m4_t __riscv_xl_vdsmul_vs_i32m4_i32m4(vint32m4_t vs2, vint32m4_t vs1, size_t vl);
+    vint32m8_t __riscv_xl_vdsmul_vs_i32m8_i32m8(vint32m8_t vs2, vint32m8_t vs1, size_t vl);
 
 * ``vdsmacini.v`` sew = 8/16/32  none_m_preds[none,_m]
 

--- a/source/toolchain/llvm/intro.rst
+++ b/source/toolchain/llvm/intro.rst
@@ -73,6 +73,10 @@ Extensions Support
 
     xxlvqmacc
 
+- Nuclei custom Scalar BFloat16 Extensions
+
+    :ref:`Xxlfbf <toolchain_gnu_nuclei_bf16>`
+
 .. rubric:: Experimental Extensions
 
 LLVM supports (to various degrees) a number of experimental extensions.  All experimental extensions have ``experimental-`` as a prefix. Listed below:


### PR DESCRIPTION
1、修复了openocd中cpuinfo链接格式使用错误   
2、修复了xxlvw 扩展文档中，intrinsic name 使用错误
3、增加了xxlfbf 扩展说明中支持的指令fcvt.h.d/fcvt.d.h
4、为llvm支持的扩展介绍里面添加了xxlfbf扩展
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes documentation errors, adds new instructions, and introduces `xxlfbf` extension in LLVM toolchain.
> 
>   - **Documentation Fixes**:
>     - Corrects `cpuinfo` link format in `intro.rst`.
>     - Fixes intrinsic name errors in `nuclei_xxlvw.rst`.
>   - **Instruction Support**:
>     - Adds `fcvt.h.d` and `fcvt.d.h` instructions to `nuclei_bf16.rst`.
>   - **Extension Additions**:
>     - Adds `xxlfbf` extension to LLVM toolchain in `intro.rst`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for 267de91b066daf606023ad58b6368d50d2e94bcd. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->