### PR TITLE
doc: Supplement the explanations of the xxldsp in the LLVM

### DIFF
--- a/source/toolchain/llvm/intro.rst
+++ b/source/toolchain/llvm/intro.rst
@@ -69,6 +69,10 @@ Extensions Support
     - xxldspn2x: xxldsp + Nuclei Custom N1 & N2
     - xxldspn3x: xxldsp + Nuclei Custom N1 & N2 & N3
 
+    .. note::
+
+        Currently, xxldsp assembly instructions implemented in LLVM only support single registers, while instructions using register pairs under rv32 behave abnormally. See `this issue <https://github.com/riscv-mcu/riscv-gnu-toolchain/issues/34>`_.
+
 - Nuclei custom VPU Extensions
 
     xxlvqmacc


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in `intro.rst` about `xxldsp` assembly instructions in LLVM only supporting single registers and issues with register pairs under `rv32`.
> 
>   - **Documentation**:
>     - Adds a note in `intro.rst` about `xxldsp` assembly instructions in LLVM only supporting single registers.
>     - Mentions abnormal behavior when using register pairs under `rv32` and links to a related GitHub issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for 78327c1b0735980fdb43768aa01b2e7b3305f59e. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->