### PR TITLE
xlmodel: Add one Known issue to xlmodel

### DIFF
--- a/source/xlmodel/intro.rst
+++ b/source/xlmodel/intro.rst
@@ -772,6 +772,7 @@ This release is based on **2025.02** version with some new features and bug fixe
 - Does not support CACHE emulation
 - Does not support booting a Linux Kernel
 - Some SMP cases for RT-Thread and Zephyr are not yet running correctly
+- When debugging with Nuclei Studio, if the ELF file lacks DWARF debug information, you need to add the ``--mem=0x0:0x10000000`` option as a workaround to prevent GDB from reporting memory read errors
 
 .. _xlmodel_changelog_202502:
 


### PR DESCRIPTION
xlmodel 添加一条 Known Issue
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add known issue in `intro.rst` for `xlmodel` regarding debugging with Nuclei Studio and missing DWARF debug information.
> 
>   - **Documentation**:
>     - Adds a known issue in `intro.rst` for `xlmodel` regarding debugging with Nuclei Studio. If the ELF file lacks DWARF debug information, the `--mem=0x0:0x10000000` option is needed to prevent GDB memory read errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for 04c15844af69af4f358bda318605c13f0735ba96. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->