### PR TITLE
Add the xxlvw extension usage notes for the vdsmacini instruction.

### DIFF
--- a/source/toolchain/gnu/nuclei_xxlvw.rst
+++ b/source/toolchain/gnu/nuclei_xxlvw.rst
@@ -206,9 +206,11 @@ Nuclei 自定义的 intrinsic
 
 .. note::
 
-    虽然该指令没有 ``vd parameter``，但是该指令的intrinsic使用时是需要一个返回值的，其返回值不为空。具体示例可参考 `Examples`_ 部分。
+    虽然该指令没有 ``vd parameter``，但是该指令的intrinsic使用时是需要一个返回值的，其返回值不为空。
 
     暂时没有 ``vd parameter`` 的指令intrinsic，都需要一个返回值。
+
+    而且如果后续程序没有用到该返回值，需要用 ``volatile`` 关键字来声明该返回值，防止开启 -O2 以及更高级别优化时被优化掉，示例可参考 `Examples`_ 部分。
 
     未来该类型指令的intrinsic的使用方法可能会有变化，目前只是一个workaround版本。
 
@@ -717,8 +719,8 @@ Examples
         vint32m1_t vd = __riscv_xl_vdscmul_vv_i32m1(vs2, vs1, vl);
         __riscv_vse32_v_i32m1(&dst_cmul[0].i32, vd, vl);
 
-        // tmp值可以不被用到，但是需要有，才能保证vdsmacini指令正常使用
-        vint32m1_t tmp = __riscv_xl_vdsmacini_x_i32m1(1, vl);
+        // tmp值可以不被用到，但是需要有，才能保证vdsmacini指令正常使用，且需要用 volatile 修饰，防止被优化
+        volatile vint32m1_t tmp = __riscv_xl_vdsmacini_x_i32m1(1, vl);
 
         vd = __riscv_xl_vdscmaco_vv_i32m1(vs2, vs1, vl);
         __riscv_vse32_v_i32m1(&dst_cmac[0].i32, vd, vl);


### PR DESCRIPTION
为xxlvw 扩展 vdsmacini 指令补充使用说明，强调目前需要加上 volatile 关键字才能保证程序绝对正确
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add documentation note on using `volatile` with `vdsmacini` instruction in `nuclei_xxlvw.rst` to prevent optimization issues.
> 
>   - **Documentation**:
>     - Update `nuclei_xxlvw.rst` to include a note on using `volatile` with `vdsmacini` instruction to prevent optimization issues.
>     - Example in `Examples` section updated to use `volatile` with `vint32m1_t tmp` for `vdsmacini` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for e1f3bc736a32879f98f6efcf22dcc118a33912dd. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->