### PR TITLE
doc: LLVM mtune in 2025.10 Toolchain Only Supports RV32

### DIFF
--- a/source/toolchain/changelog.rst
+++ b/source/toolchain/changelog.rst
@@ -50,7 +50,7 @@ Version 2025.10
 
 - Fixed: Fix unnecessary ``slli/srai`` instruction generation when using int16 type.
 
-- LLVM: Initial implementation of pipeline support for Nuclei processor ``100/200/300/600/900/1000`` series(RV32 Only).
+- LLVM: Initial implementation of pipeline support for Nuclei processor ``100/200/300/600/900/1000`` series.
 
 - LLVM: Added scalar BFloat16 support for Nuclei processors.
 

--- a/source/toolchain/changelog.rst
+++ b/source/toolchain/changelog.rst
@@ -50,7 +50,7 @@ Version 2025.10
 
 - Fixed: Fix unnecessary ``slli/srai`` instruction generation when using int16 type.
 
-- LLVM: Initial implementation of pipeline support for Nuclei processor ``100/200/300/600/900/1000`` series.
+- LLVM: Initial implementation of pipeline support for Nuclei processor ``100/200/300/600/900/1000`` series(RV32 Only).
 
 - LLVM: Added scalar BFloat16 support for Nuclei processors.
 

--- a/source/toolchain/llvm/intro.rst
+++ b/source/toolchain/llvm/intro.rst
@@ -152,3 +152,17 @@ If you need to report an issue to the developers, please provide:
 1. The ``gcc/build.txt`` file (located in the GCC directory) for GCC compilation details.
 
 2. The ``gcc/gitrepo.txt`` file to confirm commit IDs of each tool, which helps determine more detailed build information.
+
+Known Issues
+============
+
+The LLVM 2025.10 implementation contains a bug in the nuclei ``-mtune`` support.
+
+-------------------------------------------------
+
+When the LLVM Nuclei scheduling definitions were added, the processor models were declared with the generic ``RISCVProcessorModel`` instead of the architecture-tuned ``RISCVTuneProcessorModel``.
+
+References:
+
+- https://github.com/riscv-mcu/riscv-gnu-toolchain/issues/37
+


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds documentation for a known issue in LLVM 2025.10 regarding Nuclei `-mtune` support in `intro.rst`.
> 
>   - **Documentation**:
>     - Adds a "Known Issues" section in `intro.rst` for LLVM 2025.10.
>     - Describes a bug in Nuclei `-mtune` support where processor models use `RISCVProcessorModel` instead of `RISCVTuneProcessorModel`.
>     - References GitHub issue for more details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for 756928ed78b139b903478cbd221f7ca30170771f. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->