### PR TITLE
doc: Update Nuclei custom bf16 extension documentation

### DIFF
--- a/source/toolchain/gnu/nuclei_bf16.rst
+++ b/source/toolchain/gnu/nuclei_bf16.rst
@@ -219,6 +219,7 @@ Nuclei 自定义的指令
 * Vector Floating-Point Merge Instruction
     - ``vfmerge.vfm``
 * Vector Floating-Point Move Instruction
+    - ``vmv.v``
     - ``vfmv.v``
 * Single-Width Floating-Point/Integer Type-Convert Instructions
     - ``vfcvt.xu.f.v``
@@ -487,7 +488,7 @@ Examples
     }
 
 
-.. _rvv-intrinsic-doc: https://github.com/riscv-non-isa/rvv-intrinsic-doc/releases/tag/v1.0.0-rc7
+.. _rvv-intrinsic-doc: https://github.com/riscv-non-isa/rvv-intrinsic-doc/releases/tag/v1.0-ratified
 .. _vector-bfloat16-spec.adoc: https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/9328aba3fca494717de08502ff32819a7c168daa/doc/vector-bfloat16-spec.adoc
 .. _bfloat16 intrinsic_funcs: https://github.com/riscv-non-isa/rvv-intrinsic-doc/tree/9328aba3fca494717de08502ff32819a7c168daa/auto-generated/bfloat16/intrinsic_funcs
 .. _riscv-bfloat16 release v1.0: https://github.com/riscv/riscv-bfloat16/releases

--- a/source/toolchain/llvm/intro.rst
+++ b/source/toolchain/llvm/intro.rst
@@ -77,9 +77,9 @@ Extensions Support
 
     xxlvqmacc
 
-- Nuclei custom Scalar BFloat16 Extensions
+- Nuclei custom BFloat16 Extensions
 
-    :ref:`Xxlfbf <toolchain_gnu_nuclei_bf16>`
+    :ref:`Xxlfbf <toolchain_gnu_nuclei_bf16>`, :ref:`Xxlvfbf <toolchain_gnu_nuclei_bf16>`
 
 .. rubric:: Experimental Extensions
 


### PR DESCRIPTION
  * The RVV intrinsic documentation supplement the vmv instruction.
  * The _rvv-intrinsic-doc link has been updated from v1.0-rec7 to v1.0-ratified.
  * Added vector bf16 extension Xxlvfbf to LLVM extension support.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Nuclei bf16 documentation and add vector bf16 extension to LLVM support.
> 
>   - **Documentation Updates**:
>     - Add `vmv.v` to vector floating-point move instructions in `nuclei_bf16.rst`.
>     - Update `_rvv-intrinsic-doc` link from `v1.0-rec7` to `v1.0-ratified` in `nuclei_bf16.rst`.
>   - **LLVM Extension Support**:
>     - Add `Xxlvfbf` to Nuclei custom BFloat16 Extensions in `intro.rst`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nuclei-Software%2Fnuclei-tool-guide&utm_source=github&utm_medium=referral)<sup> for c06da7131805c8f5162166d664daf3af40b0ec1e. You can [customize](https://app.ellipsis.dev/Nuclei-Software/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->